### PR TITLE
Add conan build for the repo

### DIFF
--- a/.github/workflows/_test_common.sh
+++ b/.github/workflows/_test_common.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+_realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+_CURDIR=$(_realpath $(dirname "$0"))
+ROOTDIR="${_CURDIR}/../../"
+
+IMAGENAME=lucteo/action-cxx-toolkit.v9.main:latest
+
+# Export the general params that need to be added do 'docker run'
+DOCKER_RUN_PARAMS="--rm -it --workdir /github/workspace -v ${ROOTDIR}:/github/workspace -v ${ROOTDIR}/build/gh-checks/conan-cache:/root/.conan2"
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+ORANGE="\033[0;33m"
+BLUE="\033[0;34m"
+PURPLE="\033[0;35m"
+CYAN="\033[0;36m"
+LIGHTGRAY="\033[0;37m"
+DARKGRAY="\033[1;30m"
+LIGHTRED="\033[1;31m"
+LIGHTGREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+LIGHTBLUE="\033[1;34m"
+LIGHTPURPLE="\033[1;35m"
+LIGHTCYAN="\033[1;36m"
+WHITE="\033[1;37m"
+CLEAR="\033[0m"
+
+CUR_TEST=""
+
+# Prints the status of a test
+printStatus() {
+    STATUS=$1
+
+    if [ $STATUS -eq 0 ]; then
+        echo
+        echo -e "${CUR_TEST}:  [   ${LIGHTGREEN}OK${CLEAR}   ]"
+        echo
+    else
+        echo
+        echo -e "${CUR_TEST} [ ${LIGHTRED}FAILED${CLEAR} ]"
+        echo
+        exit 1
+    fi
+}
+
+# Prints the current test name
+startTest() {
+    CUR_TEST=$1
+    echo
+    echo -e "${LIGHTBLUE}Starting test: ${WHITE}${CUR_TEST}${CLEAR}"
+    echo
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
         with:
           checks: build test install warnings
           cc: gcc
+          conanflags: -o with_tests=True
           cmakeflags: -DCMAKE_TOOLCHAIN_FILE=/github/workspace/build/Release/generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release
           ctestflags: --test-dir /tmp/build/test
   clang-format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+---
+name: CI
+on: push
+jobs:
+  gcc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: docker://lucteo/action-cxx-toolkit.v9.main:latest
+        with:
+          checks: build install warnings
+          cc: gcc
+          cmakeflags: -DCMAKE_TOOLCHAIN_FILE=/github/workspace/build/Release/generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release
+          # ctestflags: --test-dir /tmp/build/test
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: docker://lucteo/action-cxx-toolkit.v9.main:latest
+        with:
+          checks: clang-format
+          clangformatdirs: src test_package/src
+  conan-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: docker://lucteo/action-cxx-toolkit.v9.main:latest
+        with:
+          checks: build
+          build_command: conan profile detect && conan create /github/workspace/ --build=missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
       - uses: actions/checkout@master
       - uses: docker://lucteo/action-cxx-toolkit.v9.main:latest
         with:
-          checks: build install warnings
+          checks: build test install warnings
           cc: gcc
           cmakeflags: -DCMAKE_TOOLCHAIN_FILE=/github/workspace/build/Release/generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release
-          # ctestflags: --test-dir /tmp/build/test
+          ctestflags: --test-dir /tmp/build/test
   clang-format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-clang-format.sh
+++ b/.github/workflows/test-clang-format.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+CURDIR=$(realpath $(dirname "$0"))
+source ${CURDIR}/_test_common.sh
+
+startTest "clang-format test"
+
+# Run docker with action-cxx-toolkit to check our code
+docker run ${DOCKER_RUN_PARAMS} \
+    -e INPUT_CHECKS='clang-format' \
+    -e INPUT_CLANGFORMATDIRS='src test_package/src' $IMAGENAME
+status=$?
+printStatus $status

--- a/.github/workflows/test-clang-format.sh
+++ b/.github/workflows/test-clang-format.sh
@@ -11,6 +11,7 @@ startTest "clang-format test"
 # Run docker with action-cxx-toolkit to check our code
 docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_CHECKS='clang-format' \
-    -e INPUT_CLANGFORMATDIRS='src test_package/src' $IMAGENAME
+    -e INPUT_CLANGFORMATDIRS='src test test_package/src' \
+    $IMAGENAME
 status=$?
 printStatus $status

--- a/.github/workflows/test-gcc.sh
+++ b/.github/workflows/test-gcc.sh
@@ -19,10 +19,10 @@ rm -fR ${CURDIR}/../../build/gh-checks/conan-cache/profiles
 docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_BUILDDIR="/github/workspace/${BUILDDIR}" \
     -e INPUT_CC='gcc' \
-    -e INPUT_CHECKS='build install warnings' \
+    -e INPUT_CHECKS='build test install warnings' \
     -e INPUT_CONANFLAGS="--output-folder /github/workspace/${BUILDDIR}" \
     -e INPUT_CMAKEFLAGS="-DCMAKE_TOOLCHAIN_FILE=/github/workspace/${BUILDDIR}/build/Release/generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release" \
+    -e INPUT_CTESTFLAGS="--test-dir /github/workspace/${BUILDDIR}/test/" \
     $IMAGENAME
 status=$?
 printStatus $status
-    # -e INPUT_CTESTFLAGS="--test-dir /github/workspace/${BUILDDIR}/test/" \

--- a/.github/workflows/test-gcc.sh
+++ b/.github/workflows/test-gcc.sh
@@ -20,7 +20,7 @@ docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_BUILDDIR="/github/workspace/${BUILDDIR}" \
     -e INPUT_CC='gcc' \
     -e INPUT_CHECKS='build test install warnings' \
-    -e INPUT_CONANFLAGS="--output-folder /github/workspace/${BUILDDIR}" \
+    -e INPUT_CONANFLAGS="--output-folder /github/workspace/${BUILDDIR} -o with_tests=True" \
     -e INPUT_CMAKEFLAGS="-DCMAKE_TOOLCHAIN_FILE=/github/workspace/${BUILDDIR}/build/Release/generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release" \
     -e INPUT_CTESTFLAGS="--test-dir /github/workspace/${BUILDDIR}/test/" \
     $IMAGENAME

--- a/.github/workflows/test-gcc.sh
+++ b/.github/workflows/test-gcc.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+CURDIR=$(realpath $(dirname "$0"))
+source ${CURDIR}/_test_common.sh
+
+startTest "GCC compilation"
+
+# Create a temporary directory to store results between runs
+BUILDDIR="build/gh-checks/gcc/"
+mkdir -p "${CURDIR}/../../${BUILDDIR}"
+
+# Remove any cached version of conan profiles
+rm -fR ${CURDIR}/../../build/gh-checks/conan-cache/profiles
+
+# Run docker with action-cxx-toolkit to check our code
+docker run ${DOCKER_RUN_PARAMS} \
+    -e INPUT_BUILDDIR="/github/workspace/${BUILDDIR}" \
+    -e INPUT_CC='gcc' \
+    -e INPUT_CHECKS='build install warnings' \
+    -e INPUT_CONANFLAGS="--output-folder /github/workspace/${BUILDDIR}" \
+    -e INPUT_CMAKEFLAGS="-DCMAKE_TOOLCHAIN_FILE=/github/workspace/${BUILDDIR}/build/Release/generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release" \
+    $IMAGENAME
+status=$?
+printStatus $status
+    # -e INPUT_CTESTFLAGS="--test-dir /github/workspace/${BUILDDIR}/test/" \

--- a/.github/workflows/test-package.sh
+++ b/.github/workflows/test-package.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+CURDIR=$(realpath $(dirname "$0"))
+source ${CURDIR}/_test_common.sh
+
+startTest "Conan package usage test"
+
+SRCFILES="$@"
+
+# Create a temporary directory to store results between runs
+BUILDDIR="build/gh-checks/package/"
+mkdir -p "${CURDIR}/../../${BUILDDIR}"
+
+# Run docker with action-cxx-toolkit to check our code
+docker run ${DOCKER_RUN_PARAMS} \
+    -e INPUT_CHECKS='build' \
+    -e INPUT_DIRECTORY="/github/workspace" \
+    -e INPUT_BUILDDIR="/github/workspace/${BUILDDIR}" \
+    -e INPUT_BUILD_COMMAND='conan profile detect ; conan create /github/workspace/ --build=missing' \
+    $IMAGENAME
+status=$?
+printStatus $status
+

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 *.out
 *.app
 
+# IDE
+.vscode
+
 # Build system
 build
 CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # IDE
 .vscode
+CMakePresets.json
 
 # Build system
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.24)
 project(context_core_api CXX)
 
 find_package(Boost COMPONENTS context CONFIG REQUIRED)
@@ -9,12 +9,8 @@ target_compile_features(context_core_api PUBLIC cxx_std_17)
 target_link_libraries(context_core_api PUBLIC Boost::context)
 set_target_properties(context_core_api PROPERTIES PUBLIC_HEADER "include/context_core_api.h")
 
-# Turn all warnings
-target_compile_options(context_core_api PUBLIC
-     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-          -Wall>
-     $<$<CXX_COMPILER_ID:MSVC>:
-          /W4>)
+# Turn on warning-as-error
+set_property(TARGET context_core_api PROPERTY COMPILE_WARNING_AS_ERROR ON)
 
 message(STATUS "With tests: ${WITH_TESTS}")
 if(${WITH_TESTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ target_compile_options(context_core_api PUBLIC
      $<$<CXX_COMPILER_ID:MSVC>:
           /W4>)
 
-message(STATUS "Building with tests")
-add_subdirectory(test)
+message(STATUS "With tests: ${WITH_TESTS}")
+if(${WITH_TESTS})
+     add_subdirectory(test)
+endif()
 
 install(TARGETS context_core_api)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(Boost COMPONENTS context CONFIG REQUIRED)
 add_library(context_core_api src/context_core_api.cpp)
 target_include_directories(context_core_api PUBLIC include)
 target_compile_features(context_core_api PUBLIC cxx_std_17)
-target_link_libraries(context_core_api Boost::context)
+target_link_libraries(context_core_api PUBLIC Boost::context)
 
 set_target_properties(context_core_api PROPERTIES PUBLIC_HEADER "include/context_core_api.h")
 install(TARGETS context_core_api)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,16 @@ add_library(context_core_api src/context_core_api.cpp)
 target_include_directories(context_core_api PUBLIC include)
 target_compile_features(context_core_api PUBLIC cxx_std_17)
 target_link_libraries(context_core_api PUBLIC Boost::context)
-
 set_target_properties(context_core_api PROPERTIES PUBLIC_HEADER "include/context_core_api.h")
+
+# Turn all warnings
+target_compile_options(context_core_api PUBLIC
+     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+          -Wall>
+     $<$<CXX_COMPILER_ID:MSVC>:
+          /W4>)
+
+message(STATUS "Building with tests")
+add_subdirectory(test)
+
 install(TARGETS context_core_api)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,10 +1,11 @@
 from conan import ConanFile
-from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.build import check_min_cppstd
 
-
-class ContextCoreApiConan(ConanFile):
+class ContextCoreApiRecipe(ConanFile):
     name = "context_core_api"
     version = "1.0.0"
+    package_type = "library"
 
     # Optional metadata
     license = "Boost"
@@ -15,22 +16,33 @@ class ContextCoreApiConan(ConanFile):
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
-    options = {}
-    default_options = {}
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
     exports_sources = "CMakeLists.txt", "src/*", "include/*"
 
+    def validate(self):
+        check_min_cppstd(self, "17")
+        
     def requirements(self):
-        self.requires("boost/1.79.0")
+        self.requires("boost/1.80.0")
+        self.requires("catch2/3.4.0")
 
     def config_options(self):
-        pass
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self)
 
     def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
         tc = CMakeToolchain(self)
         tc.generate()
 
@@ -46,15 +58,15 @@ class ContextCoreApiConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["context_core_api"]
 
-    # cpp_info.components["mycomp"].includedirs
-    # cpp_info.components["mycomp"].libdirs
-
 # from <root>/build/ directory, run:
-#   > conan install .. --build=missing
+#   > conan install .. --build=missing -s compiler.cppstd=17
 #
 # then:
-#   > conan build ..
+#   > conan build .. -s compiler.cppstd=17
 #
 # publish and test the package with:
 #   > conan export ..
 #   > conan test ../test_package context_core_api/1.0.0 --build=missing
+#
+# or, to run everything in one go:
+#   > conan create .. --build=missing -s compiler.cppstd=17

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,11 +16,11 @@ class ContextCoreApiRecipe(ConanFile):
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "with_tests": [True, False]}
+    default_options = {"shared": False, "fPIC": True, "with_tests": False}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "CMakeLists.txt", "src/*", "test/*", "include/*"
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
 
     def validate(self):
         check_min_cppstd(self, "17")
@@ -44,6 +44,7 @@ class ContextCoreApiRecipe(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
+        tc.variables["WITH_TESTS"] = self.options.with_tests
         tc.generate()
 
     def build(self):
@@ -59,7 +60,7 @@ class ContextCoreApiRecipe(ConanFile):
         self.cpp_info.libs = ["context_core_api"]
 
 # from <root>/build/ directory, run:
-#   > conan install .. --build=missing -s compiler.cppstd=17
+#   > conan install .. --build=missing -s compiler.cppstd=17 -o with_tests=True
 #
 # then:
 #   > conan build .. -s compiler.cppstd=17
@@ -70,3 +71,5 @@ class ContextCoreApiRecipe(ConanFile):
 #
 # or, to run everything in one go:
 #   > conan create .. --build=missing -s compiler.cppstd=17
+#
+# Note: changing `with_tests` value requires deleting the temporary build files.

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,7 +20,7 @@ class ContextCoreApiRecipe(ConanFile):
     default_options = {"shared": False, "fPIC": True}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+    exports_sources = "CMakeLists.txt", "src/*", "test/*", "include/*"
 
     def validate(self):
         check_min_cppstd(self, "17")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,12 +10,8 @@ add_executable(test.context_core_api ${sourceFiles})
 target_link_libraries(test.context_core_api PRIVATE context_core_api Catch2::Catch2WithMain)
 target_include_directories(test.context_core_api PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
-# Turn all warnings
-target_compile_options(test.context_core_api PUBLIC
-     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-          -Wall>
-     $<$<CXX_COMPILER_ID:MSVC>:
-          /W4>)
+# Turn on warning-as-error
+set_property(TARGET test.context_core_api PROPERTY COMPILE_WARNING_AS_ERROR ON)
 
 # Discover the Catch2 test built by the application
 include(CTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+# The source files for the tests
+set(sourceFiles
+"test_smoke.cpp"
+)
+
+find_package(Catch2 REQUIRED CONFIG)
+
+# Add the tests executable
+add_executable(test.context_core_api ${sourceFiles})
+target_link_libraries(test.context_core_api PRIVATE context_core_api Catch2::Catch2WithMain)
+target_include_directories(test.context_core_api PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Turn all warnings
+target_compile_options(test.context_core_api PUBLIC
+     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+          -Wall>
+     $<$<CXX_COMPILER_ID:MSVC>:
+          /W4>)
+
+# Discover the Catch2 test built by the application
+include(CTest)
+include(Catch)
+catch_discover_tests(test.context_core_api)
+

--- a/test/test_smoke.cpp
+++ b/test/test_smoke.cpp
@@ -1,0 +1,3 @@
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Smoke test", "[smoke]") { REQUIRE(true); }

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -2,16 +2,12 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 
 
 class ContextCoreApiTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    # VirtualBuildEnv and VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
-    # (it will be defined in Conan 2.0)
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
-    apply_env = False
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -25,6 +21,6 @@ class ContextCoreApiTestConan(ConanFile):
         cmake_layout(self)
 
     def test(self):
-        if not cross_building(self):
-            cmd = os.path.join(self.cpp.build.bindirs[0], "example")
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
             self.run(cmd, env="conanrun")

--- a/test_package/src/example.cpp
+++ b/test_package/src/example.cpp
@@ -1,5 +1,5 @@
 #include "context_core_api.h"
 
 int main() {
-    (void) context_core_api_make_fcontext(nullptr, 0, nullptr);
+  // (void) context_core_api_make_fcontext(nullptr, 0, nullptr);
 }


### PR DESCRIPTION
Use conan 2 recipe to build and test the library. Currently we test that we can properly use the package from a different package and we have just a smoke unit test.
We pull in boost (for boost.context) and Catch2 for unit testing